### PR TITLE
Strips the # character out of the destination filename.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function Upload(el, opts, config) {
   opts = this.opts = opts || {};
   config = this.config = copy(config || opts.config || window.S3);
 
-  this.filename = el.value.split('fakepath\\')[1].replace(/[\(]?[\)]?[\%]?[\+]?[#]?/g, '');
+  this.filename = el.value.split('fakepath\\')[1].replace(/[\(\)\%\+#]/g, '');
   this.name = (opts.format ? opts.format : formatName)(config.prefix, this.filename);
 
   if (!opts.protocol) opts.protocol = window.location.protocol;


### PR DESCRIPTION
- s3 cannot handle hashes ("#") in filenames. 
- This just strips them for everyone.
