### PR TITLE
Improve getting the uploaded filename.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ function Upload(el, opts, config) {
   opts = this.opts = opts || {};
   config = this.config = copy(config || opts.config || window.S3);
 
-  this.filename = el.value.split('fakepath\\')[1].replace(/[\(\)\%\+#]/g, '');
+  var filename = el.value.replace(/^C:\\fakepath\\/i, '');
+  this.filename = filename.replace(/[\(\)%\+#]/g, '');
   this.name = (opts.format ? opts.format : formatName)(config.prefix, this.filename);
 
   if (!opts.protocol) opts.protocol = window.location.protocol;


### PR DESCRIPTION
Firefox doesn't have "fakepath," so upload failed there.
